### PR TITLE
Add starter Flutter camera app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# satrcam
+# Satrcam
+
+This is a simple starter Flutter camera application.
+
+## Getting Started
+
+Ensure you have Flutter installed. Then run:
+
+```bash
+flutter pub get
+flutter run
+```
+
+The app uses the [`camera`](https://pub.dev/packages/camera) plugin and requests camera permissions on Android and iOS.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.satrcam">
+
+    <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-feature android:name="android.hardware.camera"/>
+
+    <application
+        android:label="satrcam"
+        android:icon="@mipmap/ic_launcher">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CFBundleDevelopmentRegion</key>
+<string>$(DEVELOPMENT_LANGUAGE)</string>
+<key>CFBundleExecutable</key>
+<string>$(EXECUTABLE_NAME)</string>
+<key>CFBundleIdentifier</key>
+<string>com.example.satrcam</string>
+<key>CFBundleInfoDictionaryVersion</key>
+<string>6.0</string>
+<key>CFBundleName</key>
+<string>satrcam</string>
+<key>NSCameraUsageDescription</key>
+<string>Need camera access to take pictures.</string>
+</dict>
+</plist>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:camera/camera.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final cameras = await availableCameras();
+  final firstCamera = cameras.first;
+  runApp(MyApp(camera: firstCamera));
+}
+
+class MyApp extends StatelessWidget {
+  final CameraDescription camera;
+  const MyApp({Key? key, required this.camera}) : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Camera App',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: TakePictureScreen(camera: camera),
+    );
+  }
+}
+
+class TakePictureScreen extends StatefulWidget {
+  final CameraDescription camera;
+  const TakePictureScreen({Key? key, required this.camera}) : super(key: key);
+  @override
+  TakePictureScreenState createState() => TakePictureScreenState();
+}
+
+class TakePictureScreenState extends State<TakePictureScreen> {
+  late CameraController _controller;
+  late Future<void> _initializeControllerFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = CameraController(widget.camera, ResolutionPreset.medium);
+    _initializeControllerFuture = _controller.initialize();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Take a picture')),
+      body: FutureBuilder<void>(
+        future: _initializeControllerFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.done) {
+            return CameraPreview(_controller);
+          } else {
+            return const Center(child: CircularProgressIndicator());
+          }
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          try {
+            await _initializeControllerFuture;
+            await _controller.takePicture();
+          } catch (e) {
+            debugPrint('$e');
+          }
+        },
+        child: const Icon(Icons.camera_alt),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,21 @@
+name: satrcam
+description: A starter Flutter camera app.
+publish_to: 'none'
+version: 1.0.0+1
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  camera: ^0.10.0+1
+
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add minimal Flutter app with camera plugin
- configure Android and iOS for camera permissions
- document usage in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a3bd202d08333b5f3ab431d91d368