### PR TITLE
Make camera preview full screen with overlaid capture button

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -56,37 +56,56 @@ class _TakePictureScreenState extends State<TakePictureScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: FutureBuilder<void>(
-        future: _initializeControllerFuture,
-        builder: (context, snapshot) {
-          if (snapshot.connectionState == ConnectionState.done) {
-            return CameraPreview(_controller);
-          } else {
-            return const Center(child: CircularProgressIndicator());
-          }
-        },
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () async {
-          try {
-            await _initializeControllerFuture;
-            final image = await _controller.takePicture();
-            if (!mounted) return;
-            await Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) =>
-                    DisplayPictureScreen(imagePath: image.path),
+    return FutureBuilder<void>(
+      future: _initializeControllerFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        return Scaffold(
+          body: Stack(
+            children: [
+              Positioned.fill(
+                child: FittedBox(
+                  fit: BoxFit.cover,
+                  child: SizedBox(
+                    width: _controller.value.previewSize!.height,
+                    height: _controller.value.previewSize!.width,
+                    child: CameraPreview(_controller),
+                  ),
+                ),
               ),
-            );
-          } catch (e) {
-            // Ignore errors for now.
-          }
-        },
-        child: const Icon(Icons.camera_alt),
-      ),
-      floatingActionButtonLocation:
-          FloatingActionButtonLocation.centerFloat,
+              Align(
+                alignment: Alignment.bottomCenter,
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 32),
+                  child: FloatingActionButton(
+                    onPressed: () async {
+                      try {
+                        await _initializeControllerFuture;
+                        final image = await _controller.takePicture();
+                        if (!mounted) return;
+                        await Navigator.of(context).push(
+                          MaterialPageRoute(
+                            builder: (context) =>
+                                DisplayPictureScreen(imagePath: image.path),
+                          ),
+                        );
+                      } catch (e) {
+                        // Ignore errors for now.
+                      }
+                    },
+                    child: const Icon(Icons.camera_alt),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- Display camera preview using a Stack that covers the entire screen
- Overlay the capture button at the bottom center of the preview

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688eb08531e08333a717cdb793fd98b7