### PR TITLE
Save captured photos to gallery

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:gallery_saver/gallery_saver.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -87,6 +88,7 @@ class _TakePictureScreenState extends State<TakePictureScreen> {
                       try {
                         await _initializeControllerFuture;
                         final image = await _controller.takePicture();
+                        await GallerySaver.saveImage(image.path);
                         if (!mounted) return;
                         await Navigator.of(context).push(
                           MaterialPageRoute(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
     sdk: flutter
 
   camera: ^0.10.5+2
+  gallery_saver: ^2.3.2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- save captured images to the device gallery using gallery_saver
- add gallery_saver dependency

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_688eed63fc188333b1266c9b3bf40db9